### PR TITLE
Scan: directory management improvements

### DIFF
--- a/PyRMenuGen.py
+++ b/PyRMenuGen.py
@@ -241,6 +241,11 @@ def decode_options():
 			if sd in SPECIAL_FOLDERS:
 				continue
 
+			# There might be files in the root directory;
+			# don't add these to the list
+			if not os.path.isdir(os.path.join(data_dir, sd)):
+				continue
+
 			sd_name = sd
 			# Strip just the directory name off the /really/long/path/where/it/is
 			if '/' in sd_name:

--- a/PyRMenuGen.py
+++ b/PyRMenuGen.py
@@ -32,6 +32,8 @@ from ccd import dataScraperCCD
 #
 ###############################################################
 
+SPECIAL_FOLDERS = ['.CacheDeleteDiscardedCaches', '.Spotlight-V100', '.Trashes', '.fseventsd',]
+
 def title():
 	print("%s	- RMENU list.ini and .iso generator for the SEGA Saturn" % __file__)
 	print("		Rhea/Phoebe optical drive emulator")
@@ -235,6 +237,10 @@ def decode_options():
 		data_sub_dirs_tuples = os.listdir(data_dir)
 		data_sub_dirs = []
 		for sd in data_sub_dirs_tuples:
+			# OS metadata-related; skip all of these
+			if sd in SPECIAL_FOLDERS:
+				continue
+
 			sd_name = sd
 			# Strip just the directory name off the /really/long/path/where/it/is
 			if '/' in sd_name:

--- a/PyRMenuGen.py
+++ b/PyRMenuGen.py
@@ -225,6 +225,9 @@ def decode_options():
 		for i in range(1,999):
 			v = "%03d" % i
 			valid_subdirs.append(v)
+			if i < 100:
+				v = "%02d" % i
+				valid_subdirs.append(v)
 	
 		##########################################
 		#


### PR DESCRIPTION
This makes a few improvements to the `scan` option's directory management:

* Some OSs (for example, OS X) have special OS directories. PyRMenuGen shouldn't treat them as containing games.
* There may, for various reasons, be files in the root directory. PyRMenuGen should check if something is a directory before trying to list files in it.
* Support two-digit directory names (`01`, `02`, etc.) without throwing a warning, since the README documents those as supported.