### PR TITLE
Add an ISO/MDF scraper

### DIFF
--- a/PyRMenuGen.py
+++ b/PyRMenuGen.py
@@ -25,6 +25,7 @@ import traceback
 import settings
 from cdi import dataScraperCDI
 from ccd import dataScraperCCD	
+from iso import dataScraperISO
 
 ###############################################################
 #
@@ -338,10 +339,10 @@ def decode_options():
 				image_data = dataScraperCDI(i, verbose)
 			elif i['is_ccd']:
 				image_data = dataScraperCCD(i, verbose)
-			#elif i['is_mdf']:
-			#	image_data = dataScraperMDF(i, verbose)
-			#elif i['is_iso']:
-			#	image_data = dataScraperISO(i, verbose)
+			elif i['is_mdf']:
+				image_data = dataScraperISO(i, verbose, is_mdf=True)
+			elif i['is_iso']:
+				image_data = dataScraperISO(i, verbose)
 			else:
 				pass
 			if image_data:

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ A tool to generate a menu file as used by the Rhea/Phoebe optical drive emulator
 
   * Scanning and extraction of disc data for CloneCD (.img)
   * Scanning and extraction of disc data for and DiscJuggler (.cdi) - for several disc type variants
-  * Scanning and extraction of disc data for Alcohol 120% (.mdf) - *Not yet implemented*
-  * Scanning and extraction of disc data for iso/cue (.iso) - *Not yet implemented*
+  * Scanning and extraction of disc data for Alcohol 120% (.mdf)
+  * Scanning and extraction of disc data for iso/cue (.iso)
   * Generation of the RMENU `LIST.INI` file
   * Can choose to generate an original `RMENU ISO`, or `Rmenu Kai ISO` at runtime
   * Generates a bootable `ISO` file via a call to mkisofs

--- a/iso.py
+++ b/iso.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+
+import os.path
+import settings
+
+def dataScraperISO(image_data, verbose, is_mdf=False):
+    """ Attempt to extract the disc name, version, date etc from a generic ISO or Alcohol 120% MDF image file """
+
+    # MDF is headered, but can otherwise be handled the same
+    if is_mdf:
+        base = 16
+    else:
+        base = 0
+    
+    disc_data = {
+        'title' : "",
+        'region' : "",
+        'version' : "",
+        'number' : "",
+        'date' : "",
+    }
+    
+    f = open(os.path.join(image_data['dir'], image_data['filename']), "rb")
+    f.seek(base, 0)
+
+    text_bytes = f.read(15)
+    try:
+        s = text_bytes.decode('ascii')
+    except Exception as e:
+        s = text_bytes
+
+    if s == settings.DISC_STRING:
+        if verbose:
+            if is_mdf:
+                print("--- ! [MDF] %s @ %s" % (s, base))
+            else:
+                print("--- ! [ISO] %s @ %s" % (s, base))
+        found = True
+
+            
+    ####################################
+    #
+    # Extract a disc title
+    #
+    ####################################
+    if found is False:
+        f.close()
+        return disc_data
+    else:
+        f.seek(base + 96, 0)
+        text_bytes = f.read(settings.DISC_TITLE_SIZE)
+        try:
+            s = text_bytes.decode('ascii').rstrip()
+            disc_data['title'] = s
+        except Exception as e:
+            print("--- x [Disc Title] Unable to extract disc title")
+        if verbose:
+            print("--- ! [Disc Title] %s" % (s))
+            
+    ####################################
+    #
+    # Extract a disc region
+    #
+    ####################################
+    f.seek(base + 64, 0)
+    text_bytes = f.read(settings.DISC_REGION_SIZE)
+    try:
+        s = text_bytes.decode('ascii')
+        disc_data['region'] = s
+    except Exception as e:
+        print("--- x [Disc Region] Unable to extract disc region")
+    if verbose:
+        print("--- ! [Disc Region] %s" % (s))
+    
+    ####################################
+    #
+    # Extract a disc version
+    #
+    ####################################
+    f.seek(base + 42, 0)
+    text_bytes = f.read(settings.DISC_VERSION_SIZE)
+    try:
+        s = text_bytes.decode('ascii')
+        disc_data['version'] = s
+    except Exception as e:
+        print("--- x [Disc Version] Unable to extract disc version")
+    if verbose:
+        print("--- ! [Disc Version] %s" % (s))
+    
+    ####################################
+    #
+    # Extract a disc date
+    #
+    ####################################
+    f.seek(base + 48, 0)
+    text_bytes = f.read(settings.DISC_DATE_SIZE)
+    try:
+        s = text_bytes.decode('ascii')
+        disc_data['date'] = s
+    except Exception as e:
+        print("--- x [Disc Date] Unable to extract disc date")
+    if verbose:
+        print("--- ! [Disc Date] %s" % (s))
+    
+    ####################################
+    #
+    # Extract a disc number
+    #
+    ####################################
+    f.seek(base + 59, 0)
+    text_bytes = f.read(settings.DISC_NUMBER_SIZE)
+    try:
+        s = text_bytes.decode('ascii')
+        disc_data['number'] = s
+    except Exception as e:
+        print("--- x [Disc Number] Unable to extract disc number")
+    if verbose:
+        print("--- ! [Disc Number] %s" % (s))
+    
+    f.close()
+    
+    # Return all found disc data
+    return disc_data


### PR DESCRIPTION
This adds a scraper for plain ISOs and for Alcohol 120% MDFs. ISO and MDF files can be handled the same for the purposes of this scraper except that MDF has a 16-byte header, which is easy enough to check for. I've tested this with several things I've got access to, for example:

```
- Dragon Force II.iso
--- ! [ISO] SEGA SEGASATURN @ 0
--- ! [Disc Title] DRAGON FORCE 2
--- ! [Disc Region] UE
--- ! [Disc Version] V1.006
--- ! [Disc Date] 19980309
--- ! [Disc Number] 1/1
```

```
- 335 Virtual On Cybertroopers (U).mdf
--- ! [MDF] SEGA SEGASATURN @ 16
--- ! [Disc Title] VIRTUAL-ON
--- ! [Disc Region] UTJ
--- ! [Disc Version] V1.000
--- ! [Disc Date] 19961018
--- ! [Disc Number] 1/1
```